### PR TITLE
Update Shell.c

### DIFF
--- a/Shell.c
+++ b/Shell.c
@@ -327,7 +327,11 @@ void shell_task()
 					continue;
 				// If string matches one on the list
 #ifdef ARDUINO
+#ifdef ESP8266
+				if (!strcmp(argv_list[0], list[i].shell_command_string)) {
+#else
 				if (!strcmp_P(argv_list[0], list[i].shell_command_string)) {
+#endif
 #else
 				if (!strcmp(argv_list[0], list[i].shell_command_string)) {
 #endif		


### PR DESCRIPTION
Fixes:

> undefined reference to `strncmp_P'

When building with ESP8266 core, 2.4.0-RC2.