### PR TITLE
Fix unused variable warning

### DIFF
--- a/Shell.c
+++ b/Shell.c
@@ -74,7 +74,7 @@ static void shell_format(const char * fmt, va_list va);
 
 /**
  * Process escaped character inside command args string
- *  
+ *
  * @param argc The total number of arguments received for the command
  * @param argv	Pointers to the argument strings
  */
@@ -281,7 +281,7 @@ void shell_print_error(int error, const char * field)
 #endif
 }
 
-void shell_task()
+int shell_task()
 {
 	// Number of characters written to buffer (this should be static var)
 	static uint16_t count = 0;
@@ -292,7 +292,7 @@ void shell_task()
 	char rxchar = 0;
 
 	if (!initialized)
-		return;
+		return retval;
 
 	// Process buffered output if enabled
 	if (obhandle != 0) {
@@ -358,7 +358,7 @@ void shell_task()
 				if (!strcmp_P(argv_list[0], list[i].shell_command_string))
 #else
 				if (!strcmp(argv_list[0], list[i].shell_command_string))
-#endif  
+#endif
 				{
 					// Run the appropriate function
 					retval = list[i].shell_program(argc, argv_list);
@@ -379,6 +379,7 @@ void shell_task()
 			shell_prompt();
 		}
 	}
+  return retval;
 }
 
 #ifdef ARDUINO

--- a/Shell.h
+++ b/Shell.h
@@ -13,7 +13,7 @@
 
 	You should have received a copy of the GNU General Public License
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 	Author website: http://www.geekfactory.mx
 	Author e-mail: ruben at geekfactory dot mx
  */
@@ -185,19 +185,19 @@ extern "C" {
 	 * otherwise.
 	 */
 	bool shell_init(shell_reader_t reader, shell_writer_t writer, char * msg);
-	
+
 	/**
 	 * @brief Enables internal output buffer for output chars
-	 * 
+	 *
 	 * Call this function to enable the use of an internal buffer to temporary store
 	 * characters that will be sent to a remote device. This function is meant to be
-	 * used when the communication channel performs better when many characters are 
-	 * written at the same time. For example TCP/IP sockets perform better if a group 
+	 * used when the communication channel performs better when many characters are
+	 * written at the same time. For example TCP/IP sockets perform better if a group
 	 * of characters are sent on a single segment.
-	 * 
+	 *
 	 * The content of the internal buffer is written when the it is full or if
 	 * 200 milliseconds have elapsed since the last character write on the buffer.
-	 * 
+	 *
          * @param writer The callback function used to write a group of characters on the
 	 * stream.
          */
@@ -228,10 +228,10 @@ extern "C" {
 
 	/**
 	 * @brief Prints a character to the terminal
-	 * 
+	 *
 	 * Prints a single character to the terminal screen, it exposes the functionality
 	 * of the shell_writer callback function
-	 * 
+	 *
 	 * @param c A character to print to the terminal screen
 	 */
 	void shell_putc(char c);
@@ -301,7 +301,7 @@ extern "C" {
 	 * this function should be called frequently so it can handle the input from the
 	 * data stream.
 	 */
-	void shell_task();
+	int shell_task();
 
 #ifdef ARDUINO
 	/**
@@ -333,7 +333,7 @@ extern "C" {
 	 * specifiers (subsequences beginning with '%'), the additional arguments
 	 * following format are formatted and inserted in the resulting string
 	 * replacing their respective specifiers.
-	 * 
+	 *
 	 * This function is designed to be used with strings stored in flash.
 	 *
 	 * This function implements it's own mechanism for text formatting. It doesn't


### PR DESCRIPTION
There is a compiler warning about the unused `retval` variable in `void shell_task()`:

```
Compiling .pio/build/mega-station-debug/libbcc/GeekFactory Shell Library_ID1946/Shell.c.o                                                                                                                                                    
.pio/libdeps/mega-station-debug/GeekFactory Shell Library_ID1946/Shell.c: In function 'shell_task':                                                                                                                                          
.pio/libdeps/mega-station-debug/GeekFactory Shell Library_ID1946/Shell.c:290:6: warning: variable 'retval' set but not used [-Wunused-but-set-variable]                                                                                      
  int retval = 0;
      ^
```

This PR fixes this (and a couple of whitespace issues) by letting `shell_task()`  return the `retval` which I assume you intended anyways.