### PR TITLE
Resolve issue #14 consecutive spaces

### DIFF
--- a/Shell.c
+++ b/Shell.c
@@ -457,9 +457,26 @@ static int shell_parse(char * buf, char ** argv, unsigned short maxargs)
 
 			// Handle special char: Space is token separator
 		case ' ':
+			//TODO is there other whitespace to handle?
 			if (toggle == 0) {
+				shell_printf("Got space, i=%d\r\n",i);
 				buf[i] = '\0';
+
+				// Try a loop?
+				while((i < length) && (buf[i + 1] == ' ')){
+					shell_printf("Got another space. i = %d\r\n",i);
+					i++;
+					buf[i] = '\0';
+				}
+				shell_printf("End of whitespace, i=%d length = %d\r\n",i,length);
+
+				if(i == length - 2){	// if we're at the end of the input (length - 2 because we're on the last char, and length points to char after terminating NULL
+					shell_printf("End of input, i=%d\r\n");
+					break;
+				}
+
 				argc++;
+				shell_printf("Adding arg %d\r\n",argc);
 				argv[argc] = &buf[i + 1];
 			}
 			break;

--- a/Shell.c
+++ b/Shell.c
@@ -457,26 +457,23 @@ static int shell_parse(char * buf, char ** argv, unsigned short maxargs)
 
 			// Handle special char: Space is token separator
 		case ' ':
-			//TODO is there other whitespace to handle?
 			if (toggle == 0) {
-				shell_printf("Got space, i=%d\r\n",i);
 				buf[i] = '\0';
 
-				// Try a loop?
+				// Loop past any consecutive spaces
 				while((i < length) && (buf[i + 1] == ' ')){
-					shell_printf("Got another space. i = %d\r\n",i);
 					i++;
 					buf[i] = '\0';
 				}
-				shell_printf("End of whitespace, i=%d length = %d\r\n",i,length);
 
-				if(i == length - 2){	// if we're at the end of the input (length - 2 because we're on the last char, and length points to char after terminating NULL
-					shell_printf("End of input, i=%d\r\n");
-					break;
+				// If we're at the end of the input (length - 2 because we're on the last char,
+				// and length points to char after terminating NULL
+				if(i == length - 2){
+					break;	// Break out of loop to avoid adding an empty argument at the end
 				}
 
+				// Increment argument counter and add argument to argv array
 				argc++;
-				shell_printf("Adding arg %d\r\n",argc);
 				argv[argc] = &buf[i + 1];
 			}
 			break;


### PR DESCRIPTION
Resolves issue #14, consecutive spaces results in multiple empty arguments.  This PR adds a loop in the shell_parse function which skips consecutive spaces so that empty arguments aren't added.