### PR TITLE
Fixed issue #16 so that shell_print_commands() no longer crashes

### DIFF
--- a/Shell.c
+++ b/Shell.c
@@ -204,7 +204,11 @@ void shell_print_commands()
 #endif
 	for (i = 0; i < CONFIG_SHELL_MAX_COMMANDS; i++) {
 		if (list[i].shell_program != 0 || list[i].shell_command_string != 0) {
+#ifdef ARDUINO
+			shell_println_pm(list[i].shell_command_string);
+#else
 			shell_println(list[i].shell_command_string);
+#endif
 		}
 	}
 }

--- a/examples/Shell_Print_Commands/Shell_Print_Commands.ino
+++ b/examples/Shell_Print_Commands/Shell_Print_Commands.ino
@@ -1,0 +1,94 @@
+/**
+ * GeekFactory - "Construye tu propia tecnologia"
+ * Distribucion de materiales para el desarrollo e innovacion tecnologica
+ * www.geekfactory.mx
+ *
+ * Ejemplo para shell_print_commands(). Este ejemplo es una copia de
+ * Shell_Basic con un comando de "ayuda" adicional que enumera todos los
+ * comandos registrados por llamando a shell_print_commanads ().  
+ *
+ * Example for shell_print_commands(). This example is a copy of Shell_Basic
+ * with an additional "help" command that lists all registered commands by
+ * calling shell_print_commanads().
+ */
+
+#include <Shell.h>
+
+void setup()
+{
+  // Prepare serial communication
+  Serial.begin(9600);
+  // Wait after reset or power on...
+  delay(1000);
+
+  // Initialize command line interface (CLI)
+  // We pass the function pointers to the read and write functions that we implement below
+  // We can also pass a char pointer to display a custom start message
+  shell_init(shell_reader, shell_writer, 0);
+
+  // Add commands to the shell
+  shell_register(command_mycommand, PSTR("mycommand"));
+  shell_register(command_othercommand, PSTR("othercommand"));
+  shell_register(command_help, PSTR("help"));
+}
+
+void loop()
+{
+  // This should always be called to process user input
+  shell_task();
+}
+
+/**
+ * Test commands: The commands should always use this function prototype.
+ * They receive 2 parameters: The total count of arguments (argc) and a pointer 
+ * to the begining of each one of the null-terminated argument strings.
+ *
+ * In this example we ignore the parameters passed to the functions
+ */
+int command_mycommand(int argc, char** argv)
+{
+  shell_println("Running \"mycommand\" now");
+  shell_println("Exit...");
+  return SHELL_RET_SUCCESS;
+}
+
+int command_othercommand(int argc, char** argv)
+{
+  shell_println("Running \"othercommand\" now");
+  shell_println("Exit...");
+  return SHELL_RET_SUCCESS;
+}
+
+int command_help(int argc, char** argv)
+{
+  shell_println("Running \"help\" now");
+  shell_print_commands();
+  shell_println("Exit...");
+  return SHELL_RET_SUCCESS;
+}
+
+/**
+ * Function to read data from serial port
+ * Functions to read from physical media should use this prototype:
+ * int my_reader_function(char * data)
+ */
+int shell_reader(char * data)
+{
+  // Wrapper for Serial.read() method
+  if (Serial.available()) {
+    *data = Serial.read();
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Function to write data to serial port
+ * Functions to write to physical media should use this prototype:
+ * void my_writer_function(char data)
+ */
+void shell_writer(char data)
+{
+  // Wrapper for Serial.write() method
+  Serial.write(data);
+}


### PR DESCRIPTION
Resolves issue #16, shell_print_commands() crashes. This PR adds an `#ifdef ARDUINO` wrapper to the `shell_print_commands()` function's loop so that the correct print_ln function gets called.

The PR also adds an example showing the usage of `shell_print_commands()` that I used for testing.  The example is a copy of Shell_Basic with an extra "help" command added.  The example also has a description in English *and* my own barely passable Spanish ;)