### PR TITLE
Resolve issue #22 doubled output

### DIFF
--- a/Shell.c
+++ b/Shell.c
@@ -124,6 +124,9 @@ void shell_use_buffered_output(shell_bwriter_t writer)
 	obd.shell_bwriter = writer;
 	obd.buffercount = 0;
 	obd.buffertimer = millis();
+
+	// Set shell_writer to 0 so that it's no longer called
+	shell_writer = 0;
 }
 
 bool shell_register(shell_program_t program, const char * string)

--- a/Shell.c
+++ b/Shell.c
@@ -152,21 +152,23 @@ void shell_unregister_all()
 
 void shell_putc(char c)
 {
-	if (initialized != false && shell_writer != 0)
-		shell_writer(c);
-	if (initialized != false && obhandle != 0) {
-		// Keep track of last byte
-		obhandle->buffertimer = millis();
-		// Empty buffer if it´s full before storing anything else
-		if (obhandle->buffercount >= 30) {
-			// Write output...
-			if (obhandle->shell_bwriter != 0)
-				obhandle->shell_bwriter(obhandle->outbuffer, obhandle->buffercount);
-			// and clear counter
-			obhandle->buffercount = 0;
+	if (initialized != false) {
+		if (shell_writer != 0) {
+			shell_writer(c);
+		} else if (obhandle != 0) {
+			// Keep track of last byte
+			obhandle->buffertimer = millis();
+			// Empty buffer if it´s full before storing anything else
+			if (obhandle->buffercount >= 30) {
+				// Write output...
+				if (obhandle->shell_bwriter != 0)
+					obhandle->shell_bwriter(obhandle->outbuffer, obhandle->buffercount);
+				// and clear counter
+				obhandle->buffercount = 0;
+			}
+			// Write to buffer always
+			obhandle->outbuffer[obhandle->buffercount++] = c;
 		}
-		// Write to buffer always
-		obhandle->outbuffer[obhandle->buffercount++] = c;
 	}
 }
 


### PR DESCRIPTION
Fixed issue #22 so shell_putc() only prints once when using buffered output.  When `shell_use_buffered_output` is called it sets `shell_writer` to 0 so that the original function is never called.  This PR also reworks the `if` statements in `shell_putc` to be more clear and so that only one writer function will be called.