### PR TITLE
Add output buffer flushes to reduce latency

### DIFF
--- a/Shell.c
+++ b/Shell.c
@@ -344,10 +344,12 @@ void shell_task()
 				count++;
 
 				// If we're using buffered output, flush the output buffer so the user gets immediate feedback on their key press
-				if (obhandle->shell_bwriter != 0)
-					obhandle->shell_bwriter(obhandle->outbuffer, obhandle->buffercount);
+				if (obhandle != 0) {
+					if (obhandle->shell_bwriter != 0)
+						obhandle->shell_bwriter(obhandle->outbuffer, obhandle->buffercount);
 					// and clear counter
 					obhandle->buffercount = 0;
+				}
 			}
 		}
 		// Check if a full command is available on the buffer to process
@@ -515,6 +517,14 @@ static void shell_prompt()
 #else
 	shell_print((const char *) "device>");
 #endif
+
+	// If we're using buffered output, flush the output buffer so the user gets immediate feedback on their key press
+	if (obhandle != 0) {
+		if (obhandle->shell_bwriter != 0)
+			obhandle->shell_bwriter(obhandle->outbuffer, obhandle->buffercount);
+		// and clear counter
+		obhandle->buffercount = 0;
+	}
 }
 
 /*-------------------------------------------------------------*

--- a/Shell.c
+++ b/Shell.c
@@ -342,6 +342,12 @@ void shell_task()
 				shellbuf[count] = rxchar;
 				shell_putc(rxchar);
 				count++;
+
+				// If we're using buffered output, flush the output buffer so the user gets immediate feedback on their key press
+				if (obhandle->shell_bwriter != 0)
+					obhandle->shell_bwriter(obhandle->outbuffer, obhandle->buffercount);
+					// and clear counter
+					obhandle->buffercount = 0;
 			}
 		}
 		// Check if a full command is available on the buffer to process


### PR DESCRIPTION
Add a buffer flush (when buffered output is in use) after receiving a
printable char and when printing the prompt to reduce the overall shell latency (ie, delay between the user pressing a key and
seeing the character echoed back)