### PR TITLE
Allow user to specify a bigger output buffer

### DIFF
--- a/Shell.c
+++ b/Shell.c
@@ -158,7 +158,7 @@ void shell_putc(char c)
 		// Keep track of last byte
 		obhandle->buffertimer = millis();
 		// Empty buffer if it´s full before storing anything else
-		if (obhandle->buffercount >= 30) {
+		if (obhandle->buffercount >= CONFIG_SHELL_OUT_BUFFER_LEN) {
 			// Write output...
 			if (obhandle->shell_bwriter != 0)
 				obhandle->shell_bwriter(obhandle->outbuffer, obhandle->buffercount);

--- a/Shell.h
+++ b/Shell.h
@@ -74,10 +74,9 @@
 /**
  * This macro defines the length of the output buffer.  This should be large
  * enough to accommodate most large writes via the shell_print functions, but
- * still small enough to fit in a single shell_bwriter call (ie, for Telnet,
- * smaller than the TCP Maximum Transmission Unit, 1500 bytes).  This buffer is
- * also statically allocated, and should not be so large that it uses all the
- * available RAM in the system.
+ * still small enough to fit in a single shell_bwriter call (ie, UINT_8T_MAX,
+ * 255 bytes).  This buffer is also statically allocated, and should not be so
+ * large that it uses all the available RAM in the system.
  */
 #define CONFIG_SHELL_OUT_BUFFER_LEN		30
 

--- a/Shell.h
+++ b/Shell.h
@@ -72,6 +72,16 @@
 #endif
 
 /**
+ * This macro defines the length of the output buffer.  This should be large
+ * enough to accommodate most large writes via the shell_print functions, but
+ * still small enough to fit in a single shell_bwriter call (ie, for Telnet,
+ * smaller than the TCP Maximum Transmission Unit, 1500 bytes).  This buffer is
+ * also statically allocated, and should not be so large that it uses all the
+ * available RAM in the system.
+ */
+#define CONFIG_SHELL_OUT_BUFFER_LEN		30
+
+/**
  * End of user configurable parameters, do not touch anything below this line
  */
 
@@ -158,7 +168,7 @@ struct shell_command_entry {
 };
 
 struct shell_outbuffer_data {
-	char outbuffer[30];
+	char outbuffer[CONFIG_SHELL_OUT_BUFFER_LEN];
 	shell_bwriter_t shell_bwriter;
 	uint32_t buffertimer;
 	uint8_t buffercount;


### PR DESCRIPTION
This PR creates a macro `CONFIG_SHELL_OUT_BUFFER_LEN` which defines the length of the output buffer.  This should be large enough to accommodate most large writes via the `shell_print` functions, but still small enough to fit in a single `shell_bwriter` call (ie, UINT_8T_MAX, 255 bytes).  This buffer is also statically allocated, and should not be so large that it uses all the available RAM in the system.  The macro is set to the original output buffer size (30 bytes).